### PR TITLE
Dev/fontaxis names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Extends AppKit's `NSFont`, UIKit's `UIFont` and SwiftUI's `Font` with variable f
 ```swift
 let font = NSFont(name: "Amstelvar", size: 20, axes: [
 	.weight: 650,
-	.opticalSize: 100,
-	"XTRA": 700,
+	.opticalSize: 144,
+	"GRAD": 500,
 ])
 ```
 
@@ -34,7 +34,7 @@ print(axes)
 /*
 [VariableFonts.FontAxis(
 	id: 1481789268,
-	name: FontAxis.Name.custom("XROT"),
+	name: "XROT",
 	description: "Rotation in X",
 	minimumValue: -45.0,
 	maximumValue: 45.0,

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Extends AppKit's `NSFont`, UIKit's `UIFont` and SwiftUI's `Font` with variable f
 ### Initializing font with axes.
 ```swift
 let font = NSFont(name: "Amstelvar", size: 20, axes: [
-	"wght": 650,
-	"opsz": 100,
+	.weight: 650,
+	.opticalSize: 100,
 	"XTRA": 700,
 ])
 ```
@@ -23,7 +23,7 @@ let font = NSFont(name: "Amstelvar", size: 20, axes: [
 ### New font with a single axis applied
 ```swift
 let scienceGothic = UIFont(name: "ScienceGothic", size: 20)!
-let slanted = scienceGothic.withAxis("slnt", value: -10)
+let slanted = scienceGothic.withAxis(.slant, value: -10)
 ```
 
 ### Get all available axes of a font
@@ -34,7 +34,7 @@ print(axes)
 /*
 [VariableFonts.FontAxis(
 	id: 1481789268,
-	name: "XROT",
+	name: FontAxis.Name.custom("XROT"),
 	description: "Rotation in X",
 	minimumValue: -45.0,
 	maximumValue: 45.0,
@@ -47,7 +47,7 @@ etc...]
 ```swift
 Text("Hello world")
 	.font(.custom(name: "Fraunces", size: 40, axes: [
-		"wght": 900,
+		.weight: 900,
 		"SOFT": 100,
 		"WONK": 1,
 	]))
@@ -65,3 +65,6 @@ let megaNunito = nunito.withAxes(
 	})
 )
 ```
+
+## Axis names
+The dictionary you supply to configure the axes use [`FontAxis.Name`](Sources/VariableFonts/FontAxis.swift#L38) as keys. This type comes with a set of well known axis names. I.e. `.weight` (`wght`), `.width` (`wdth`), etc. This type is `ExpressibleByStringLiteral`. String literals can be used for custom axis names.

--- a/Sources/VariableFonts/FontAxis.swift
+++ b/Sources/VariableFonts/FontAxis.swift
@@ -9,7 +9,7 @@ import CoreText
 /// Description of a single font axis.
 public struct FontAxis: Identifiable, Hashable, Equatable {
 	public let id: UInt32
-	public let name: String
+	public let name: Name
 	public let description: String
 
 	public let minimumValue: CGFloat
@@ -28,10 +28,53 @@ public struct FontAxis: Identifiable, Hashable, Equatable {
 		}
 
 		self.id = id
-		self.name = idToName(id)
+		self.name = Name(rawValue: idToName(id))
 		self.description = description
 		self.minimumValue = minimum
 		self.maximumValue = maximum
 		self.defaultValue = `default`
+	}
+
+	/// An axis name.
+	///
+	/// The enum comes with a set of well known axis names (i.e `.weight` for `"wdth"`) for convenience.
+	/// Use string literals to refer to a custom axis name.
+	/// ```swift
+	/// let weightAxis: FontAxis.Name = .weight
+	/// let xtraAxis: FontAxis.Name = "XTRA"
+	/// ```
+	public enum Name: CustomStringConvertible, ExpressibleByStringLiteral, Hashable {
+		case italic
+		case opticalSize
+		case slant
+		case weight
+		case width
+		case custom(String)
+
+		public init(rawValue: String) {
+			self = switch rawValue {
+			case "ital": .italic
+			case "opsz": .opticalSize
+			case "slnt": .slant
+			case "wght": .weight
+			case "wdth": .width
+			default: .custom(rawValue)
+			}
+		}
+
+		public init(stringLiteral value: String) {
+			self.init(rawValue: value)
+		}
+
+		public var description: String {
+			switch self {
+			case .italic: "ital"
+			case .opticalSize: "opsz"
+			case .slant: "slnt"
+			case .weight: "wght"
+			case .width: "wdth"
+			case .custom(let name): name
+			}
+		}
 	}
 }

--- a/Sources/VariableFonts/Utils.swift
+++ b/Sources/VariableFonts/Utils.swift
@@ -3,7 +3,7 @@
 //  Created by Freek (github.com/frzi) 2023
 //
 
-package func idToName(_ id: UInt32) -> String {
+func idToName(_ id: UInt32) -> String {
 	var str = ""
 	for a in (0 ..< 4).reversed() {
 		if let scalar = UnicodeScalar((id >> (a * 8)) & 0xFF) {
@@ -13,7 +13,11 @@ package func idToName(_ id: UInt32) -> String {
 	return str
 }
 
-package func nameToId(_ name: String) -> UInt32 {
+func nameToId(_ name: FontAxis.Name) -> UInt32 {
+	nameToId(name.description)
+}
+
+func nameToId(_ name: String) -> UInt32 {
 	name.compactMap { $0.asciiValue }
 		.reduce(UInt32(0)) { $0 << 8 | UInt32($1) }
 }

--- a/Sources/VariableFonts/VariableFonts.swift
+++ b/Sources/VariableFonts/VariableFonts.swift
@@ -49,7 +49,7 @@ public extension PlatformFont {
 	///		"wdth": 200, // Width
 	///	]
 	/// ```
-	convenience init?(name: String, size: CGFloat, axes: [String : CGFloat]) {
+	convenience init?(name: String, size: CGFloat, axes: [FontAxis.Name : CGFloat]) {
 		let axes = Dictionary(uniqueKeysWithValues: axes.map { key, value in
 			return (nameToId(key), value)
 		})
@@ -80,7 +80,7 @@ public extension PlatformFont {
 	}
 
 	/// Returns a new font with the applied axis, using the name as key.
-	func withAxis(_ name: String, value: CGFloat) -> Self {
+	func withAxis(_ name: FontAxis.Name, value: CGFloat) -> Self {
 		let id = nameToId(name)
 		let descriptor = Self.descriptorFor(name: fontName, axes: [
 			id: value
@@ -103,7 +103,7 @@ public extension PlatformFont {
 	}
 
 	/// Returns a new font with the applied axex, using the name as key.
-	func withAxes(_ axes: [String : CGFloat]) -> Self {
+	func withAxes(_ axes: [FontAxis.Name : CGFloat]) -> Self {
 		let axes: [UInt32 : CGFloat] = Dictionary(uniqueKeysWithValues: axes.map { key, value in
 			return (nameToId(key), value)
 		})
@@ -132,7 +132,7 @@ public extension Font {
 	///			axes: ["opsz": 100]
 	///		))
 	/// ```
-	static func custom(name: String, size: CGFloat, axes: [String : CGFloat]) -> Font {
+	static func custom(name: String, size: CGFloat, axes: [FontAxis.Name : CGFloat]) -> Font {
 		guard let font = PlatformFont(name: name, size: size, axes: axes) else {
 			return .system(size: size)
 		}

--- a/Sources/VariableFonts/VariableFonts.swift
+++ b/Sources/VariableFonts/VariableFonts.swift
@@ -33,7 +33,7 @@ public extension PlatformFont {
 	///	let axes: [UInt32 : CGFloat] = [
 	///		2003072104: 400, // Weight
 	///		2003072104: 200, // Width
-	///		1380930649: 45, // Custom Y rotation axis (ROTY)
+	///		1498566484: 45, // Custom Y rotation axis (YROT)
 	///	]
 	/// ```
 	convenience init?(name: String, size: CGFloat, axes: [UInt32 : CGFloat]) {
@@ -48,7 +48,7 @@ public extension PlatformFont {
 	///	let axes: [FontAxis.Name : CGFloat] = [
 	///		.weight: 400, // Weight
 	///		.width: 200, // Width
-	///		"ROTY": 45, // Custom Y rotation axis
+	///		"YROT": 45, // Custom Y rotation axis
 	///	]
 	/// ```
 	convenience init?(name: String, size: CGFloat, axes: [FontAxis.Name : CGFloat]) {

--- a/Sources/VariableFonts/VariableFonts.swift
+++ b/Sources/VariableFonts/VariableFonts.swift
@@ -33,6 +33,7 @@ public extension PlatformFont {
 	///	let axes: [UInt32 : CGFloat] = [
 	///		2003072104: 400, // Weight
 	///		2003072104: 200, // Width
+	///		1380930649: 45, // Custom Y rotation axis (ROTY)
 	///	]
 	/// ```
 	convenience init?(name: String, size: CGFloat, axes: [UInt32 : CGFloat]) {
@@ -42,11 +43,12 @@ public extension PlatformFont {
 
 	/// Initialize a font with the given axes using names.
 	///
-	/// This initializer expects a dictionary with axis names (`String`) as key.
+	/// This initializer expects a dictionary with axis names (`FontAxis.Name`) as key.
 	/// ```swift
-	///	let axes: [String : CGFloat] = [
-	///		"wght": 400, // Weight
-	///		"wdth": 200, // Width
+	///	let axes: [FontAxis.Name : CGFloat] = [
+	///		.weight: 400, // Weight
+	///		.width: 200, // Width
+	///		"ROTY": 45, // Custom Y rotation axis
 	///	]
 	/// ```
 	convenience init?(name: String, size: CGFloat, axes: [FontAxis.Name : CGFloat]) {
@@ -129,7 +131,10 @@ public extension Font {
 	///		.font(.custom(
 	///			name: "Amstelvar",
 	///			size: 20,
-	///			axes: ["opsz": 100]
+	///			axes: [
+	///				.opticalSize: 144,
+	///				"GRAD": 500,
+	///			]
 	///		))
 	/// ```
 	static func custom(name: String, size: CGFloat, axes: [FontAxis.Name : CGFloat]) -> Font {

--- a/Tests/VariableFontsTests/VariableFontsTests.swift
+++ b/Tests/VariableFontsTests/VariableFontsTests.swift
@@ -29,4 +29,21 @@ final class VariableFontsTests: XCTestCase {
 			XCTAssertEqual(idToName(id), name, "ID \(id) does NOT match name \(name).")
 		}
 	}
+
+	func testEquality() throws {
+		let values: [FontAxis.Name : String] = [
+			.italic: "ital",
+			.slant: "slnt",
+			.opticalSize: "opsz",
+			.weight: "wght",
+			.width: "wdth",
+			.custom("wdth"): "wdth",
+			.custom("XTRA"): "XTRA",
+			"ROTY": "ROTY",
+		]
+
+		for (name, rawName) in values {
+			XCTAssertEqual(name.description, FontAxis.Name(rawValue: rawName).description)
+		}
+	}
 }


### PR DESCRIPTION
Introduces the `FontAxis.Name` type. An enum that comes with a set of well known axis names for convenience.